### PR TITLE
Create simple QR code generator web page

### DIFF
--- a/.github/workflows/frontend-web.yml
+++ b/.github/workflows/frontend-web.yml
@@ -1,0 +1,26 @@
+name: Frontend Web
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Build web
+        env:
+          EXPO_NO_INTERACTIVE: 1
+        run: npx expo export --platform web --output-dir dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# qr-code-generator
+# QR Code Generator
+
+This repository contains a minimal [Expo](https://expo.dev) project for generating QR codes on the web.
+
+The app uses `react-native-qrcode-svg` to render the QR code image.
+
+## Getting Started
+
+```
+cd apps/frontend
+npm install
+npm run web
+```
+
+This will open the Expo development server in the browser.

--- a/apps/frontend/App.js
+++ b/apps/frontend/App.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import QRCode from 'react-native-qrcode-svg';
+
+export default function App() {
+  const [text, setText] = useState('');
+  const [value, setValue] = useState('');
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 }}>
+      <TextInput
+        placeholder="Enter text"
+        style={{ borderWidth: 1, borderColor: '#ccc', width: '100%', padding: 10, marginBottom: 20 }}
+        onChangeText={setText}
+        value={text}
+      />
+      <Button title="Generate QR" onPress={() => setValue(text)} />
+      {value ? (
+        <View style={{ marginTop: 20 }}>
+          <QRCode value={value} size={200} />
+        </View>
+      ) : null}
+      <StatusBar style="auto" />
+    </View>
+  );
+}

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,0 +1,12 @@
+# Expo QR Code Generator
+
+This is a minimal Expo web app for generating QR codes.
+
+## Development
+
+Install dependencies and run the web version:
+
+```bash
+npm install
+npm run web
+```

--- a/apps/frontend/babel.config.js
+++ b/apps/frontend/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/apps/frontend/index.js
+++ b/apps/frontend/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "qr-code-generator",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~52.0.47",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-native": "0.76.9",
+    "react-native-qrcode-svg": "^6.3.15"
+  }
+}


### PR DESCRIPTION
## Summary
- add Expo-based QR code generator in `apps/frontend`
- document how to run the Expo web app
- update GitHub Actions workflow to build the Expo web project

## Testing
- `node -v`
- `npm -v`
- `npm install` in `apps/frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c1598beb88330930d504beeedfe65