### PR TITLE
Fix Expo web build

### DIFF
--- a/apps/frontend/app.json
+++ b/apps/frontend/app.json
@@ -1,0 +1,7 @@
+{
+  "expo": {
+    "name": "qr-code-generator",
+    "slug": "qr-code-generator",
+    "platforms": ["web"]
+  }
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,10 +8,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~4.0.1",
     "expo": "~52.0.47",
+    "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "0.76.9",
-    "react-native-qrcode-svg": "^6.3.15"
+    "react-native-qrcode-svg": "^6.3.15",
+    "react-native-web": "~0.19.13"
   }
 }


### PR DESCRIPTION
## Summary
- add missing web dependencies
- create `app.json` with web platform

## Testing
- `npx --yes expo export --platform web --output-dir dist`

------
https://chatgpt.com/codex/tasks/task_e_688c72454ff88330a0a84bb198976c84